### PR TITLE
Set session cookie lifetime after user login.

### DIFF
--- a/config/schema/remember_me.schema.yml
+++ b/config/schema/remember_me.schema.yml
@@ -1,0 +1,16 @@
+remember_me.settings_form:
+  type: config_object
+  label: 'Remember Me settings'
+  mapping:
+    remember_me_managed:
+      type: bool
+      label: 'Manage session lifetime'
+    remember_me_lifetime:
+      type: integer
+      label: 'Lifetime'
+    remember_me_checkbox:
+      type: boolean
+      label: 'Remember me field'
+    remember_me_checkbox_visible:
+      type: bool
+      label: 'Remember me field visible'

--- a/remember_me.install
+++ b/remember_me.install
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @file
+ * Install, update and uninstall functions for remember_me module.
+ */
+
+/**
+ * Implements hook_requirements().
+ *
+ * Display information about cookie_lifetime parameter.
+ */
+function remember_me_requirements($phase) {
+  $requirements = [];
+
+  if ($phase === 'runtime') {
+    $cookie_lifetime = \Drupal::getContainer()->getParameter('session.storage.options')['cookie_lifetime'];
+    if ($cookie_lifetime > 0) {
+      $requirements['remember_me_cookie_lifetime'] = array(
+        'title' => t('Remember Me'),
+        'value' => t('If you want to logout user after end of session, set <code>session.storage.options[cookie_lifetime]</code> parameter to zero in <code>services.yml</code>.'),
+        'severity' => REQUIREMENT_WARNING
+      );
+    }
+  }
+
+  return $requirements;
+}

--- a/remember_me.module
+++ b/remember_me.module
@@ -1,37 +1,28 @@
 <?php
+/**
+ * @file
+ * Module remember_me that allow user to save session for a long time.
+ */
 
-function remember_me_user_login($account) {
-  if ($account->isAnonymous()) {
+use \Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+
+/**
+ * Implements hook_form_FORM_ID_alter() for user_login_form.
+ */
+function remember_me_form_user_login_form_alter(&$form, FormStateInterface $form_state) {
+  // Configuration for the remember me checkbox.
+  $config = \Drupal::config('remember_me.settings_form');
+  $managed = (bool) $config->get('remember_me_managed');
+  if (!$managed) {
     return;
   }
-  \Drupal::request()->getSession()->set("remember_me", "foobar");
-}
-
-function remember_me_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
-  if ($form_id == 'user_login_form') {
-    // Configuration for the remember me checkbox.
-    $is_visible = \Drupal::config('remember_me.settings_form')->get('remember_me_checkbox_visible');
-    $checked = \Drupal::config('remember_me.settings_form')->get('remember_me_checkbox');
-    $cbox['remember_me'] = array(
-      '#title' => t('Remember me'),
-      '#type' => ($is_visible === 1) ? 'checkbox' : 'hidden',
-      '#default_value' => $checked,
-      '#attributes' => array('tabindex' => 1),
-    );
-    $que = array();
-
-    while (list($key, $val) = each($form)) {
-      switch ($key) {
-        case 'name':
-        case 'pass' :
-          $val['#attributes']['tabindex'] = 1;
-          break;
-        case 'actions':
-          $form = $que + $cbox + $form;
-          $form[$key]['submit']['#attributes']['tabindex'] = 1;
-          return;
-      }
-      $que[$key] = $val;
-    }
-  }
+  $is_visible = $config->get('remember_me_checkbox_visible');
+  $checked = $config->get('remember_me_checkbox');
+  $form['remember_me'] = array(
+    '#title' => t('Remember me'),
+    '#type' => ($is_visible === 1) ? 'checkbox' : 'hidden',
+    '#default_value' => $checked,
+    '#attributes' => array('tabindex' => 1),
+  );
 }

--- a/remember_me.services.yml
+++ b/remember_me.services.yml
@@ -1,5 +1,6 @@
 services:
   remember_me_event_subscriber:
     class: Drupal\remember_me\EventSubscriber\RememberMeEventSubscriber
+    arguments: ['%session.storage.options%', '@config.factory']
     tags:
       - { name: event_subscriber }

--- a/src/EventSubscriber/RememberMeEventSubscriber.php
+++ b/src/EventSubscriber/RememberMeEventSubscriber.php
@@ -1,29 +1,49 @@
 <?php
+/**
+ * @file
+ * Contains \Drupal\remember_me\EventSubscriber\RememberMeEventSubscriber
+ */
 
 namespace Drupal\remember_me\EventSubscriber;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Drupal\Core\Database\Query;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class RememberMeEventSubscriber implements EventSubscriberInterface {
+  /**
+   * @var int
+   */
+  protected $default_lifetime;
+
+  /**
+   * @var \Drupal\Core\Config\Config
+   */
+  protected $config;
+
+  public function __construct(array $session_storage_options, ConfigFactoryInterface $config_factory) {
+    $this->default_lifetime = $session_storage_options['cookie_lifetime'];
+    $this->config = $config_factory->get('remember_me.settings_form');
+  }
 
   /**
    * Execute some code.
    */
-  public function rememberMeInit() {
-    $account = \Drupal::currentUser();
-    if ($account->isAnonymous()) {
-      return;
+  public function init() {
+    $remember_me_managed = $this->config->get('remember_me_managed');
+    $request = \Drupal::request();
+    if ($remember_me_managed && $request->get('remember_me')) {
+      $lifetime = $this->config->get('remember_me_lifetime') ?: $this->default_lifetime;
+      ini_set('session.cookie_lifetime', $lifetime);
     }
-
   }
 
   /**
    * {@inheritdoc}
    */
-  static function getSubscribedEvents() {
-    $events[KernelEvents::REQUEST][] = array('rememberMeInit');
+  public static function getSubscribedEvents() {
+    $events[KernelEvents::REQUEST][] = ['init'];
     return $events;
   }
 }

--- a/src/Form/RememberMeSettingsForm.php
+++ b/src/Form/RememberMeSettingsForm.php
@@ -3,13 +3,12 @@
  * @file
  * Contains \Drupal\remember_me\RememberMeSettingsForm
  */
+
 namespace Drupal\remember_me\Form;
 
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Url;
 use Drupal\Core\Database\Query;
-use Drupal\user\Entity\Role;
 
 /**
  * Configure hello settings for this site.
@@ -50,7 +49,7 @@ class RememberMeSettingsForm extends ConfigFormBase {
     $form['remember_me_lifetime'] = array(
       '#type' => 'select',
       '#title' => t('Lifetime'),
-      '#default_value' => ($config->get('remember_me_lifetime')) ? $config->get('remember_me_lifetime') : 604800,
+      '#default_value' => $config->get('remember_me_lifetime') ?: 604800,
       '#options' => $options,
       '#description' => t('Duration a user will be remembered for. This setting is ignored if Manage session lifetime (above) is disabled.'),
     );


### PR DESCRIPTION
Set session.cookie_lifetime php setting after user login with this option.
Add configuration schema for module settings.

Also for normal work module require to set `session.storage.options[cookie_lifetime]` parameter to zero, because only in this case user will be logged out after end of session. Added requirements for this, but maybe need to add it to README file.
